### PR TITLE
feat: add an hourly trend chart

### DIFF
--- a/app/javascript/headache_charts.js
+++ b/app/javascript/headache_charts.js
@@ -6,10 +6,13 @@ import {
   LineElement,
   LineController,
   PieController,
+  BarController,
+  BarElement,
   ArcElement,
   Legend,
   Title,
-  Tooltip
+  Tooltip,
+  CategoryScale
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 
@@ -20,10 +23,13 @@ Chart.register(
   LineElement,
   LineController,
   PieController,
+  BarController,
+  BarElement,
   ArcElement,
   Legend,
   Title,
-  Tooltip
+  Tooltip,
+  CategoryScale
 );
 
 let chartInstances = {};
@@ -143,8 +149,77 @@ function initializeMedicationChart(medicationData) {
   }
 }
 
-export function initializeCharts(intensityData, triggerData, medicationData) {
+function initializeHourlyChart(hourlyData) {
+  if (hourlyData && hourlyData.length > 0) {
+    const hourlyCtx = document.getElementById('hourlyChart');
+    if (hourlyCtx) {
+      if (chartInstances.hourlyChart) {
+        chartInstances.hourlyChart.destroy();
+      }
+      chartInstances.hourlyChart = new Chart(hourlyCtx, {
+        type: 'bar',
+        data: {
+          labels: hourlyData.map(d => d.label),
+          datasets: [
+            {
+              label: 'Frequency',
+              data: hourlyData.map(d => d.frequency),
+              backgroundColor: 'rgba(75, 192, 192, 0.6)',
+              yAxisID: 'y-frequency',
+            },
+            {
+              label: 'Avg Intensity',
+              data: hourlyData.map(d => d.avg_intensity),
+              backgroundColor: 'rgba(255, 99, 132, 0.6)',
+              yAxisID: 'y-intensity',
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          scales: {
+            x: {
+              type: 'category',
+              title: {
+                display: true,
+                text: 'Time of Day'
+              }
+            },
+            'y-frequency': {
+              type: 'linear',
+              position: 'left',
+              title: {
+                display: true,
+                text: 'Frequency'
+              },
+              beginAtZero: true
+            },
+            'y-intensity': {
+              type: 'linear',
+              position: 'right',
+              title: {
+                display: true,
+                text: 'Average Intensity'
+              },
+              beginAtZero: true,
+              max: 10
+            }
+          },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Headache Frequency and Intensity by Time of Day'
+            }
+          }
+        }
+      });
+    }
+  }
+}
+
+export function initializeCharts(intensityData, triggerData, medicationData, hourlyData) {
   initializeIntensityChart(intensityData);
   initializeTriggerChart(triggerData);
   initializeMedicationChart(medicationData);
+  initializeHourlyChart(hourlyData);
 }

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -28,11 +28,21 @@
           <p>No medication data available.</p>
         <% end %>
       </div>
+
+      <div class="bg-white p-4 rounded-lg shadow">
+        <h2 class="text-xl font-semibold mb-2">Headache Frequency and Intensity by Time of Day</h2>
+        <canvas id="hourlyChart"></canvas>
+      </div>
     </div>
 
     <script>
       document.addEventListener('turbo:load', function() {
-        window.initializeCharts(<%= raw @intensity_data.to_json %>, <%= raw @trigger_data.to_json %>, <%= raw @medication_data.to_json %>);
+        window.initializeCharts(
+          <%= raw @intensity_data.to_json %>,
+          <%= raw @trigger_data.to_json %>,
+          <%= raw @medication_data.to_json %>,
+          <%= raw @hourly_data.to_json %>
+        );
       });
     </script>
   <% else %>

--- a/test/system/headache_logs_test.rb
+++ b/test/system/headache_logs_test.rb
@@ -46,4 +46,13 @@ class HeadacheLogsTest < ApplicationSystemTestCase
 
     assert_text "Headache log was successfully destroyed"
   end
+
+  test "visiting the charts page" do
+    visit charts_index_url
+    assert_selector "h1", text: "Headache Charts"
+    assert_selector "canvas#intensityChart"
+    assert_selector "canvas#triggerChart"
+    assert_selector "canvas#medicationChart"
+    assert_selector "canvas#hourlyChart"
+  end
 end


### PR DESCRIPTION
Adds a new chart that shows the trend of attacks allowing users to visualize headache frequency and intensity based on different times of the day.
<img width="620" alt="image" src="https://github.com/user-attachments/assets/c3b16c2e-b174-4425-aa45-9487957a9927">
