### PR TITLE
feat(charts): add chart displaying number of attacks per day

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -9,6 +9,7 @@ class ChartsController < ApplicationController
     @trigger_data = process_trigger_data(@headache_logs)
     @medication_data = process_medication_data(@headache_logs)
     @hourly_data = process_hourly_data(@headache_logs)
+    @attacks_per_day_data = HeadacheLog.process_attacks_per_day_data(@headache_logs)
   end
 
   private

--- a/app/javascript/headache_charts.js
+++ b/app/javascript/headache_charts.js
@@ -217,9 +217,67 @@ function initializeHourlyChart(hourlyData) {
   }
 }
 
-export function initializeCharts(intensityData, triggerData, medicationData, hourlyData) {
+function initializeAttacksPerDayChart(attacksPerDayData) {
+  if (attacksPerDayData && Object.keys(attacksPerDayData).length > 0) {
+    const attacksPerDayCtx = document.getElementById('attacksPerDayChart');
+    if (attacksPerDayCtx) {
+      if (chartInstances.attacksPerDayChart) {
+        chartInstances.attacksPerDayChart.destroy();
+      }
+      chartInstances.attacksPerDayChart = new Chart(attacksPerDayCtx, {
+        type: 'bar',
+        data: {
+          datasets: [{
+            label: 'Number of Attacks',
+            data: attacksPerDayData,
+            backgroundColor: 'rgba(54, 162, 235, 0.6)',
+            borderColor: 'rgb(54, 162, 235)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          responsive: true,
+          scales: {
+            x: {
+              type: 'time',
+              time: {
+                unit: 'day'
+              },
+              title: {
+                display: true,
+                text: 'Date'
+              }
+            },
+            y: {
+              beginAtZero: true,
+              title: {
+                display: true,
+                text: 'Number of Attacks'
+              },
+              ticks: {
+                stepSize: 1
+              }
+            }
+          },
+          plugins: {
+            legend: {
+              display: false
+            },
+            title: {
+              display: true,
+              text: 'Number of Attacks per Day'
+            }
+          }
+        }
+      });
+    }
+  }
+}
+
+export function initializeCharts(intensityData, triggerData, medicationData, hourlyData, attacksPerDayData) {
   initializeIntensityChart(intensityData);
   initializeTriggerChart(triggerData);
   initializeMedicationChart(medicationData);
   initializeHourlyChart(hourlyData);
+  initializeAttacksPerDayChart(attacksPerDayData);
 }

--- a/app/models/headache_log.rb
+++ b/app/models/headache_log.rb
@@ -19,4 +19,11 @@ class HeadacheLog < ApplicationRecord
     headache_logs = headache_logs.with_medication(params[:medication]) if params[:medication].present?
     headache_logs
   end
+
+  def self.process_attacks_per_day_data(logs)
+    attacks_per_day = logs.group_by { |log| log.start_time.to_date }
+                          .transform_values(&:count)
+
+    attacks_per_day.map { |date, count| { x: date, y: count } }
+  end
 end

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -12,6 +12,11 @@
       </div>
 
       <div class="bg-white p-4 rounded-lg shadow">
+        <h2 class="text-xl font-semibold mb-2">Number of Attacks per Day</h2>
+        <canvas id="attacksPerDayChart"></canvas>
+      </div>
+
+      <div class="bg-white p-4 rounded-lg shadow">
         <h2 class="text-xl font-semibold mb-2">Top 5 Triggers</h2>
         <% if @trigger_data.any? %>
           <canvas id="triggerChart"></canvas>
@@ -41,7 +46,8 @@
           <%= raw @intensity_data.to_json %>,
           <%= raw @trigger_data.to_json %>,
           <%= raw @medication_data.to_json %>,
-          <%= raw @hourly_data.to_json %>
+          <%= raw @hourly_data.to_json %>,
+          <%= raw @attacks_per_day_data.to_json %>
         );
       });
     </script>

--- a/test/models/headache_log_test.rb
+++ b/test/models/headache_log_test.rb
@@ -1,7 +1,26 @@
 require "test_helper"
 
 class HeadacheLogTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should process attacks per day data correctly" do
+    user = users(:one)
+
+    # Clear existing headache logs
+    HeadacheLog.destroy_all
+
+    # Create multiple headache logs for testing
+    HeadacheLog.create!(user: user, start_time: Date.today, intensity: 5)
+    HeadacheLog.create!(user: user, start_time: Date.today, intensity: 6)
+    HeadacheLog.create!(user: user, start_time: Date.today - 1.day, intensity: 7)
+
+    headache_logs = user.headache_logs
+    # puts "All headache logs: #{headache_logs.to_a.inspect}"
+
+    attacks_per_day_data = HeadacheLog.process_attacks_per_day_data(headache_logs)
+
+    # puts "Attacks per day data: #{attacks_per_day_data.inspect}"
+
+    assert_equal 2, attacks_per_day_data.size
+    assert_equal 2, attacks_per_day_data.find { |d| d[:x] == Date.today }[:y]
+    assert_equal 1, attacks_per_day_data.find { |d| d[:x] == Date.today - 1.day }[:y]
+  end
 end

--- a/test/system/charts_test.rb
+++ b/test/system/charts_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class ChartsTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+
+    # Create some headache logs with trigger data
+    3.times do |i|
+      HeadacheLog.create!(
+        user: @user,
+        start_time: Time.current - i.days,
+        end_time: Time.current - i.days + 2.hours,
+        intensity: rand(1..10),
+        triggers: "Stress, Lack of Sleep",
+        medication: "Sumatriptan"
+      )
+    end
+  end
+
+  test "visiting the charts page" do
+    visit charts_url
+    assert_selector "h1", text: "Headache Data Visualization"
+    assert_selector "h2", text: "Headache Intensity Over Time"
+    assert_selector "h2", text: "Number of Attacks per Day"
+    assert_selector "h2", text: "Top 5 Triggers"
+    assert_selector "h2", text: "Top 5 Medications"
+    assert_selector "h2", text: "Headache Frequency and Intensity by Time of Day"
+  end
+
+  test "charts are rendered" do
+    visit charts_url
+    assert_selector "canvas#intensityChart"
+    assert_selector "canvas#attacksPerDayChart"
+    assert_selector "canvas#triggerChart"
+    assert_selector "canvas#medicationChart"
+    assert_selector "canvas#hourlyChart"
+  end
+end


### PR DESCRIPTION
- Add @attacks_per_day_data to charts_controller
- Implement initializeAttacksPerDayChart in headache_charts.js
- Define process_attacks_per_day_data in headache_log model
- Update charts view to include attacksPerDayChart
- Include unit test for process_attacks_per_day_data in headache_log_test
- Add system tests to validate new chart rendering

<img width="620" alt="image" src="https://github.com/user-attachments/assets/b4dda743-ac09-4d15-9e6b-993da70952ae">
