### PR TITLE
Fixes Rails system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,4 +19,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     logs = logs.select { |log| log.level == level } if level
     assert logs.empty?, "Unexpected console messages:\n" + logs.map(&:message).join("\n\n")
   end
+
+  def open_accordion(data_attribute)
+    # Locate the accordion using the data attribute selector
+    accordion = find("details[data-accordion=\"#{data_attribute}\"]")
+    accordion.click
+
+    assert_selector "details[open][data-accordion=\"#{data_attribute}\"]"
+  end
 end

--- a/test/system/charts_test.rb
+++ b/test/system/charts_test.rb
@@ -19,7 +19,7 @@ class ChartsTest < ApplicationSystemTestCase
 
   test "filtering chart data" do
     visit charts_url
-    click_on "Filters"
+    open_accordion "filters"
 
     fill_in "Start Date", with: Date.yesterday
     fill_in "End Date", with: Date.tomorrow
@@ -32,7 +32,7 @@ class ChartsTest < ApplicationSystemTestCase
 
   test "charts show no data message when filtered with no results" do
     visit charts_url
-    click_on "Filters"
+    open_accordion "filters"
 
     fill_in "Start Date", with: 1.year.ago
     fill_in "End Date", with: 11.months.ago

--- a/test/system/headache_logs_test.rb
+++ b/test/system/headache_logs_test.rb
@@ -10,7 +10,7 @@ class HeadacheLogsTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit headache_logs_url
-    assert_selector "h1", text: "Headache Logs"
+    assert_selector "div.navbar-center", text: "Headache Logs"
     assert_selector ".stats", count: 1
     assert_selector ".card", minimum: 1
   end
@@ -19,7 +19,7 @@ class HeadacheLogsTest < ApplicationSystemTestCase
     visit headache_logs_url
     click_on "New"
 
-    fill_in "Start time", with: Time.current.strftime("%Y-%m-%dT%H:%M")
+    fill_in "Start Time", with: Time.current.strftime("%Y-%m-%dT%H:%M")
     fill_in "Intensity", with: 7
     fill_in "Medication", with: "Sumatriptan + Oxygen"
     fill_in "Triggers", with: "Lack of sleep, Stress"
@@ -52,7 +52,7 @@ class HeadacheLogsTest < ApplicationSystemTestCase
     assert_text "Ongoing"
 
     click_on "Update Log"
-    fill_in "End time", with: Time.current.strftime("%Y-%m-%dT%H:%M")
+    fill_in "End Time", with: Time.current.strftime("%Y-%m-%dT%H:%M")
     click_on "Update Headache log"
 
     assert_text "Headache log was successfully updated"
@@ -61,7 +61,7 @@ class HeadacheLogsTest < ApplicationSystemTestCase
 
   test "filtering headache logs" do
     visit headache_logs_url
-    click_on "Filters"
+    open_accordion "filters"
 
     fill_in "Start Date", with: Date.yesterday
     fill_in "End Date", with: Date.tomorrow
@@ -74,8 +74,8 @@ class HeadacheLogsTest < ApplicationSystemTestCase
 
   test "generating and copying share link" do
     visit headache_logs_url
-    click_on "Share with Healthcare Provider"
-    click_on "Generate Share Link"
+    open_accordion "share"
+    click_on "Generate New Link"
 
     assert_text "Share link generated successfully"
 


### PR DESCRIPTION
Fixes issue_67

 - Capybara tests can now open accordions
 - Updates test to find navbar which replaced a previous H1 element
 - `fill_in` method is case-sensitive when searching for labels
 
Please note, the logic of one test `test/system/headache_logs_test.rb:75`  has been changed from generating a share link, to generating a *new* link, as there was already a share link present.