### PR TITLE
Configures devise validatable to enable password comparison

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,22 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable
+         :recoverable, :rememberable, :validatable
 
   validates :username, presence: true, uniqueness: true
 
   has_many :headache_logs
   has_many :share_tokens
 
+  def email_required?
+    false
+  end
+
   def generate_share_token
     share_tokens.create
+  end
+
+  def will_save_change_to_email?
+    false
   end
 end


### PR DESCRIPTION
Fixes #70

Configures User model to work with Devise validatable. This enables Devise to compare the password and password_confirmation fields in the registration, password change and password reset controller.

**NOTE**
This also configures a minimum password length of 6 characters, and a maximum password length of 128 characters.
Existing users with shorter passwords continue to be valid, and can still login with their existing passwords.