### PR TITLE
Update Android APK to version 2.0.0 (build 18)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ config/credentials.yml.enc diff=rails_credentials
 # Manage video files with Git LFS
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.apk filter=lfs diff=lfs merge=lfs -text
+public/cluster-headache-tracker.apk filter=lfs diff=lfs merge=lfs -text

--- a/config/initializers/app_constants.rb
+++ b/config/initializers/app_constants.rb
@@ -1,4 +1,4 @@
 # Application constants
 module AppConstants
-  ANDROID_APK_VERSION = "1.0.11"
+  ANDROID_APK_VERSION = "2.0.0"
 end

--- a/public/cluster-headache-tracker.apk
+++ b/public/cluster-headache-tracker.apk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c52baa6796935e55ae61f46fbd3874ce962804fdd7d35e8d0587c96212b357da
-size 26669631
+oid sha256:6cf36b1d3afae6a67ef98d8f5b9c1fa9275f33325891f9f469f9f2d521a490b2
+size 26668731


### PR DESCRIPTION
This PR updates the Android APK to version 2.0.0 (build 18).

## Changes
- Updated `public/cluster-headache-tracker.apk`
- Updated `ANDROID_APK_VERSION` in `config/initializers/app_constants.rb`

## APK Details
- Version: 2.0.0
- Build: 18
- GitHub Run Number: 6
- Location: `public/cluster-headache-tracker.apk`

This APK was automatically built from commit 4fdd7c67ce5bb3d1537ec5be14b9536d994e42a7.